### PR TITLE
Add Exact parameter 

### DIFF
--- a/char_limit/pi.char_limit.php
+++ b/char_limit/pi.char_limit.php
@@ -28,7 +28,7 @@ in this Software without prior written authorization from EllisLab, Inc.
 
 $plugin_info = array(
 						'pi_name'			=> 'Character Limiter',
-						'pi_version'		=> '1.1',
+						'pi_version'		=> '1.2',
 						'pi_author'			=> 'Rick Ellis',
 						'pi_author_url'		=> 'http://expressionengine.com/',
 						'pi_description'	=> 'Permits you to limit the number of characters in some text',


### PR DESCRIPTION
Add "exact" parameter to truncate the string to the given limit. 
This will bypass the normal behaviour that will not cut words.

Cheers,
Rein
