### PR TITLE
Add 'strip_tags' parameter to remove HTML tags

### DIFF
--- a/char_limit/pi.char_limit.php
+++ b/char_limit/pi.char_limit.php
@@ -63,8 +63,13 @@ class Char_limit {
 
 		//exact truncation
 		$exact = $this->EE->TMPL->fetch_param('exact', 'no');
+		$strip_tags = $this->EE->TMPL->fetch_param('strip_tags', 'no');
 		
 		$str = ($str == '') ? $this->EE->TMPL->tagdata : $str;
+
+		if ($strip_tags == 'yes') {
+			$str = strip_tags($str);
+		}
 				
  		$this->return_data = in_array($exact, array('yes', 'y')) ? substr($str, 0, $total) : $this->EE->functions->char_limiter($str, $total);
 	}
@@ -85,7 +90,7 @@ class Char_limit {
 		?>
 		Wrap anything you want to be processed between the tag pairs.
 
-		{exp:char_limit total="100" exact="no"}
+		{exp:char_limit total="100" exact="no" strip_tags="yes"}
 
 		text you want processed
 
@@ -93,6 +98,7 @@ class Char_limit {
 
 		The "total" parameter lets you specify the number of characters.
 		The "exact" parameter will truncate the string exact to the "limit"
+		The "strip_tags" parameter will remove any HTML tags from the input string
 
 		Note: When exact="no" this tag will always leave entire words intact so you may get a few additional characters than what you specify.  
 


### PR DESCRIPTION
Thought this would be a useful addition, eg. for use in meta tags or to prevent broken layout from un-closed tags when the input string is from a wysiwyg editor.